### PR TITLE
Carael/add delete option

### DIFF
--- a/src/Core/ServiceBus.Contracts/IMessageService.cs
+++ b/src/Core/ServiceBus.Contracts/IMessageService.cs
@@ -19,7 +19,7 @@ public interface IMessageService
         string queueOrTopicName,
         IReadOnlyList<SendMessage> messages,
         CancellationToken cancellationToken);
-    
+
     IAsyncEnumerable<PurgeResult> PurgeAsync(
         string connectionName,
         string topicOrQueueName,
@@ -27,12 +27,20 @@ public interface IMessageService
         SubQueue subQueue,
         long totalCount,
         CancellationToken cancellationToken);
-    
+
     IAsyncEnumerable<ResendResult> ResendAsync(string connectionName,
         string topicOrQueueName,
         string? subscriptionName,
         SubQueue subQueue,
         string destinationTopicOrQueueName,
         long totalCount,
+        CancellationToken cancellationToken);
+
+    Task<Result> DeleteMessage(
+        string connectionName,
+        string queueOrTopicName,
+        string? subscriptionName,
+        SubQueue subQueue,
+        long sequenceNumber,
         CancellationToken cancellationToken);
 }

--- a/src/Ui/Website.Host/electron.manifest.json
+++ b/src/Ui/Website.Host/electron.manifest.json
@@ -13,7 +13,7 @@
     "appId": "com.crossbusexplorer.app",
     "productName": "Cross Bus Explorer",
     "copyright": "Copyright © 2024",
-    "buildVersion": "0.4.0",
+    "buildVersion": "0.4.1",
     "compression": "maximum",
     "directories": {
       "output": "../../../bin/Desktop"

--- a/src/Ui/Website/Jobs/DeleteMessageJob.cs
+++ b/src/Ui/Website/Jobs/DeleteMessageJob.cs
@@ -1,0 +1,113 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using CrossBusExplorer.ServiceBus.Contracts;
+using CrossBusExplorer.ServiceBus.Contracts.Types;
+using CrossBusExplorer.Website.Extensions;
+using MudBlazor;
+namespace CrossBusExplorer.Website.Jobs;
+
+public class DeleteMessageJob : IJob
+{
+    private readonly string _connectionName;
+    private readonly string _queueOrTopicName;
+    private readonly string? _subscriptionName;
+    private readonly SubQueue _subQueue;
+    private readonly long _sequenceNumber;
+    private readonly IMessageService _messageService;
+    private readonly ISnackbar _snackbar;
+    private readonly CancellationTokenSource _cancellationTokenSource;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public event JobCompletedEventHandler? OnCompleted;
+
+    public DeleteMessageJob(
+        string connectionName,
+        string queueOrTopicName,
+        string? subscriptionName,
+        SubQueue subQueue,
+        long sequenceNumber,
+        IMessageService messageService)
+    {
+        _connectionName = connectionName;
+        _queueOrTopicName = queueOrTopicName;
+        _subscriptionName = subscriptionName;
+        _subQueue = subQueue;
+        _sequenceNumber = sequenceNumber;
+
+        _messageService = messageService;
+        _cancellationTokenSource = new CancellationTokenSource();
+    }
+
+    private int _progress;
+    public int Progress
+    {
+        get => _progress;
+        private set
+        {
+            _progress = value;
+            this.Notify(PropertyChanged);
+        }
+    }
+
+    public string Name =>
+        $"Delete message {_sequenceNumber} from {_queueOrTopicName} {_subscriptionName}".Trim();
+
+    public bool ViewDetails { get; set; }
+
+    private JobStatus _status;
+    public JobStatus Status
+    {
+        get => _status;
+        private set
+        {
+            _status = value;
+            this.Notify(PropertyChanged);
+        }
+    }
+    public string? ErrorMessage { get; private set; }
+    public string? WarningMessage { get; private set; }
+
+    public async Task ExecuteAsync()
+    {
+        Status = JobStatus.Running;
+
+        try
+        {
+            Result result = await _messageService.DeleteMessage(
+                _connectionName,
+                _queueOrTopicName,
+                _subscriptionName,
+                _subQueue,
+                _sequenceNumber,
+                _cancellationTokenSource.Token);
+
+            Progress = JobsHelper.GetProgress(1, result.Count);
+
+            Status = JobStatus.Succeeded;
+
+            if (result.Count == 0)
+            {
+                WarningMessage = "Message was not not deleted";
+            }
+        }
+        catch (TaskCanceledException)
+        {
+            Status = JobStatus.Cancelled;
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = $"Job {Name} failed. Error: {ex.Message}.";
+            Status = JobStatus.Failed;
+        }
+
+        await OnCompleted(_connectionName, _queueOrTopicName, _subscriptionName);
+    }
+
+    public void Cancel()
+    {
+        _cancellationTokenSource.Cancel();
+    }
+}

--- a/src/Ui/Website/Pages/Messages.razor
+++ b/src/Ui/Website/Pages/Messages.razor
@@ -8,198 +8,204 @@
 
 <MudPaper>
 
-    <div class="d-flex gap-2">
-        <MudTooltip Text="Receive messages">
-            <MudIconButton Icon="@Icons.Filled.Download" OnClick="@(() => { Model.DialogVisible = true; })" ButtonType="ButtonType.Button">Receive messages</MudIconButton>
-        </MudTooltip>
+  <div class="d-flex gap-2">
+    <MudTooltip Text="Receive messages">
+      <MudIconButton Icon="@Icons.Filled.Download" OnClick="@(() => { Model.DialogVisible = true; })" ButtonType="ButtonType.Button">Receive messages</MudIconButton>
+    </MudTooltip>
 
-        <MudTooltip Text="Send message">
-            <MudIconButton Icon="@Icons.Filled.Send" OnClick="@(() => Model.ViewMessageDetails(null, true))" ButtonType="ButtonType.Button">Send message</MudIconButton>
-        </MudTooltip>
-    </div>
+    <MudTooltip Text="Send message">
+      <MudIconButton Icon="@Icons.Filled.Send" OnClick="@(() => Model.ViewMessageDetails(null, true))" ButtonType="ButtonType.Button">Send message</MudIconButton>
+    </MudTooltip>
+  </div>
 
-    <MudTable Items="Model.Messages" Hover="true" SortLabel="Sort By" Elevation="0">
-        <HeaderContent>
-            <MudTh>
-                Actions
-            </MudTh>
-            <MudTh>
-                Message Id
-            </MudTh>
-            <MudTh>
-                      <MudTableSortLabel SortBy="new Func<Message, object>(x=>x.SystemProperties.SequenceNumber)">Seq</MudTableSortLabel>
-            </MudTh>
-            <MudTh>
-                Subject
-            </MudTh>
-            <MudTh>
-                <MudTableSortLabel SortBy="new Func<Message, object>(x=>x.SystemProperties.EnqueuedTime)">Enqueue time</MudTableSortLabel>
-            </MudTh>
-            <MudTh>
-                 <MudTableSortLabel SortBy="new Func<Message, object>(x=>x.SystemProperties.ExpiresAt)">Expiration time</MudTableSortLabel>
-            </MudTh>
-            <MudTh>
-                <MudTableSortLabel SortBy="new Func<Message, object>(x=>x.SystemProperties.ScheduledEnqueueTime)">Scheduled enqueue time</MudTableSortLabel>
-            </MudTh>
-        </HeaderContent>
-        <RowTemplate>
-            <MudTd DataLabel="Actions">
-                <MudTooltip Text="Requeue">
-                    <MudIconButton Size="Size.Small"
-                                   OnClick="@(() => Model.Requeue(QueueOrTopicName, context.ToSendMessageModel()))"
-                                   Icon="@Icons.Material.Outlined.Send"/>
-                </MudTooltip>
-                <MudTooltip Text="View message details">
-                    <MudIconButton Size="Size.Small" OnClick="@(() => Model.ViewMessageDetails(context, false))" Icon="@Icons.Material.Outlined.Preview"/>
-                </MudTooltip>
-                <MudTooltip Text="Edit message">
-                    <MudIconButton Size="Size.Small" Icon="@Icons.Material.Outlined.Edit" OnClick="@(() => Model.ViewMessageDetails(context, true))"/>
-                </MudTooltip>
-            </MudTd>
-            <MudTd DataLabel="Message Id">@context.Id</MudTd>
-            <MudTd DataLabel="Seq">@context.SystemProperties.SequenceNumber</MudTd>
-            <MudTd DataLabel="Subject">@(context.Subject ?? "-")</MudTd>
-            <MudTd DataLabel="Enqueue time">@context.SystemProperties.EnqueuedTime.ToUniversal()</MudTd>
-            <MudTd DataLabel="Expiration time">@context.SystemProperties.ExpiresAt.ToUniversal()</MudTd>
-            <MudTd DataLabel="Scheduled enqueue time">@context.SystemProperties.ScheduledEnqueueTime.ToUniversal()</MudTd>
-        </RowTemplate>
-        <PagerContent>
-            <div class="d-flex">
-                <MudTablePager PageSizeOptions="new[]{10}"/>
-                @if (Model.CanPeekMore(_formModel))
-                {
-                    <MudButton OnClick="@(() => Model.PeekMore(_formModel, default))" ButtonType="ButtonType.Button">Load more</MudButton>
-                }
-            </div>
-        </PagerContent>
-    </MudTable>
+  <MudTable Items="Model.Messages" Hover="true" SortLabel="Sort By" Elevation="0">
+    <HeaderContent>
+      <MudTh>
+        Actions
+      </MudTh>
+      <MudTh>
+        Message Id
+      </MudTh>
+      <MudTh>
+        <MudTableSortLabel SortBy="new Func<Message, object>(x => x.SystemProperties.SequenceNumber)">Seq</MudTableSortLabel>
+      </MudTh>
+      <MudTh>
+        Subject
+      </MudTh>
+      <MudTh>
+        <MudTableSortLabel SortBy="new Func<Message, object>(x => x.SystemProperties.EnqueuedTime)">Enqueue time</MudTableSortLabel>
+      </MudTh>
+      <MudTh>
+        <MudTableSortLabel SortBy="new Func<Message, object>(x => x.SystemProperties.ExpiresAt)">Expiration time</MudTableSortLabel>
+      </MudTh>
+      <MudTh>
+        <MudTableSortLabel SortBy="new Func<Message, object>(x => x.SystemProperties.ScheduledEnqueueTime)">Scheduled enqueue time</MudTableSortLabel>
+      </MudTh>
+    </HeaderContent>
+    <RowTemplate>
+      <MudTd DataLabel="Actions">
+        <MudTooltip Text="Requeue">
+          <MudIconButton Size="Size.Small"
+                         OnClick="@(() => Model.Requeue(QueueOrTopicName, context.ToSendMessageModel()))"
+                         Icon="@Icons.Material.Outlined.Send"/>
+        </MudTooltip>
+        <MudTooltip Text="View message details">
+          <MudIconButton Size="Size.Small" OnClick="@(() => Model.ViewMessageDetails(context, false))" Icon="@Icons.Material.Outlined.Preview"/>
+        </MudTooltip>
+        <MudTooltip Text="Edit message">
+          <MudIconButton Size="Size.Small" Icon="@Icons.Material.Outlined.Edit" OnClick="@(() => Model.ViewMessageDetails(context, true))"/>
+        </MudTooltip>
+        @if (Model.IsPeekMode(_formModel))
+        {
+          <MudTooltip Text="Delete message">
+            <MudIconButton Size="Size.Small" Icon="@Icons.Material.Outlined.Delete" OnClick="@(() => Model.Delete(context, _formModel.SubQueue))"/>
+          </MudTooltip>
+        }
+      </MudTd>
+      <MudTd DataLabel="Message Id">@context.Id</MudTd>
+      <MudTd DataLabel="Seq">@context.SystemProperties.SequenceNumber</MudTd>
+      <MudTd DataLabel="Subject">@(context.Subject ?? "-")</MudTd>
+      <MudTd DataLabel="Enqueue time">@context.SystemProperties.EnqueuedTime.ToUniversal()</MudTd>
+      <MudTd DataLabel="Expiration time">@context.SystemProperties.ExpiresAt.ToUniversal()</MudTd>
+      <MudTd DataLabel="Scheduled enqueue time">@context.SystemProperties.ScheduledEnqueueTime.ToUniversal()</MudTd>
+    </RowTemplate>
+    <PagerContent>
+      <div class="d-flex">
+        <MudTablePager PageSizeOptions="new[] { 10 }"/>
+        @if (Model.CanPeekMore(_formModel))
+        {
+          <MudButton OnClick="@(() => Model.PeekMore(_formModel, default))" ButtonType="ButtonType.Button">Load more</MudButton>
+        }
+      </div>
+    </PagerContent>
+  </MudTable>
 </MudPaper>
 
 <MudDialog @bind-IsVisible="Model.DialogVisible">
-    <TitleContent>
-        <MudText Typo="Typo.h6">
-            Receive @QueueOrTopicName @SubscriptionName messages
-        </MudText>
-    </TitleContent>
-    <DialogContent>
-        <MudPaper Elevation="3">
-            <MudForm @ref="@form" Model="@_formModel" Validation="@(_validator.ValidateValue)" ValidationDelay="0">
-                <MudField Variant="Variant.Outlined" Label="Queue type">
-                    <MudRadioGroup @bind-SelectedOption="_formModel.SubQueue"
-                                   For="@(() => _formModel.SubQueue)">
-                        <MudRadio Dense="true"
-                                  Size="Size.Small"
-                                  Option="SubQueue.None">
-                            Active messages
-                        </MudRadio>
-                        <MudRadio Dense="true"
-                                  Size="Size.Small"
-                                  Option="SubQueue.DeadLetter">
-                            Dead letter
-                        </MudRadio>
-                        <MudRadio Dense="true"
-                                  Size="Size.Small"
-                                  Option="SubQueue.TransferDeadLetter">
-                            Transfer dead letter
-                        </MudRadio>
-                    </MudRadioGroup>
-                </MudField>
+  <TitleContent>
+    <MudText Typo="Typo.h6">
+      Receive @QueueOrTopicName @SubscriptionName messages
+    </MudText>
+  </TitleContent>
+  <DialogContent>
+    <MudPaper Elevation="3">
+      <MudForm @ref="@form" Model="@_formModel" Validation="@(_validator.ValidateValue)" ValidationDelay="0">
+        <MudField Variant="Variant.Outlined" Label="Queue type">
+          <MudRadioGroup @bind-SelectedOption="_formModel.SubQueue"
+                         For="@(() => _formModel.SubQueue)">
+            <MudRadio Dense="true"
+                      Size="Size.Small"
+                      Option="SubQueue.None">
+              Active messages
+            </MudRadio>
+            <MudRadio Dense="true"
+                      Size="Size.Small"
+                      Option="SubQueue.DeadLetter">
+              Dead letter
+            </MudRadio>
+            <MudRadio Dense="true"
+                      Size="Size.Small"
+                      Option="SubQueue.TransferDeadLetter">
+              Transfer dead letter
+            </MudRadio>
+          </MudRadioGroup>
+        </MudField>
 
-                <MudField Variant="Variant.Outlined" Label="Receive mode">
-                    <MudRadioGroup @bind-SelectedOption="_formModel.Mode"
-                                   For="@(() => _formModel.Mode)">
-                        <MudRadio Dense="true"
-                                  Size="Size.Small"
-                                  Option="ReceiveMode.ReceiveAndDelete">
-                            Receive and delete
-                        </MudRadio>
-                        <MudRadio Dense="true"
-                                  Size="Size.Small"
-                                  Option="ReceiveMode.PeekLock">
-                            Peek lock
-                        </MudRadio>
-                    </MudRadioGroup>
-                </MudField>
+        <MudField Variant="Variant.Outlined" Label="Receive mode">
+          <MudRadioGroup @bind-SelectedOption="_formModel.Mode"
+                         For="@(() => _formModel.Mode)">
+            <MudRadio Dense="true"
+                      Size="Size.Small"
+                      Option="ReceiveMode.ReceiveAndDelete">
+              Receive and delete
+            </MudRadio>
+            <MudRadio Dense="true"
+                      Size="Size.Small"
+                      Option="ReceiveMode.PeekLock">
+              Peek lock
+            </MudRadio>
+          </MudRadioGroup>
+        </MudField>
 
-                <MudField Variant="Variant.Outlined" Label="Receive type">
-                    <MudRadioGroup @bind-SelectedOption="_formModel.Type"
-                                   For="@(() => _formModel.Type)">
+        <MudField Variant="Variant.Outlined" Label="Receive type">
+          <MudRadioGroup @bind-SelectedOption="_formModel.Type"
+                         For="@(() => _formModel.Type)">
 
-                        @* TODO: fix all receive option
+            @* TODO: fix all receive option
                             <MudRadio Dense="true" *@
-                        @*           Size="Size.Small" *@
-                        @*           Option="ReceiveType.All"> *@
-                        @*     @ReceiveType.All *@
-                        @* </MudRadio> *@
-                        <MudRadio Dense="true"
-                                  Size="Size.Small"
-                                  Option="ReceiveType.ByCount">
-                            @ReceiveType.ByCount
-                        </MudRadio>
-                    </MudRadioGroup>
-                    <MudNumericField @bind-Value="_formModel.MessagesCount"
-                                     Disabled="@(_formModel.Type == ReceiveType.All)"
-                                     For="@(() => _formModel.MessagesCount)"
-                                     T="int?"
-                                     Class="px-0 ma-0 pa-0 py-0"
-                                     Min="1"
-                                     Max="250"
-                                     Immediate="true"
-                                     HelperText="Messages count">
-                    </MudNumericField>
-                    <MudNumericField @bind-Value="_formModel.FromSequenceNumber"
-                                     T="long?"
-                                     For="@(() => _formModel.FromSequenceNumber)"
-                                     Disabled="@(_formModel.Type == ReceiveType.All || _formModel.Mode == ReceiveMode.ReceiveAndDelete)"
-                                     Class="px-0 ma-0 pa-0 py-0"
-                                     Min="0"
-                                     Immediate="true"
-                                     HelperText="From sequence number">
-                    </MudNumericField>
-                </MudField>
-            </MudForm>
-        </MudPaper>
-    </DialogContent>
-    <DialogActions>
-        <MudButton ButtonType="ButtonType.Reset"
-                   Color="Color.Default"
-                   OnClick="@(() => { Model.DialogVisible = false; })"
-                   Class="px-10">
-            Close
-        </MudButton>
-        <MudButton ButtonType="ButtonType.Button"
-                   Color="Color.Success"
-                   OnClick="@(() => Model.OnSubmitReceiveForm(form, _formModel, default))"
-                   Class="px-10">
-            Receive
-        </MudButton>
-    </DialogActions>
+            @*           Size="Size.Small" *@
+            @*           Option="ReceiveType.All"> *@
+            @*     @ReceiveType.All *@
+            @* </MudRadio> *@
+            <MudRadio Dense="true"
+                      Size="Size.Small"
+                      Option="ReceiveType.ByCount">
+              @ReceiveType.ByCount
+            </MudRadio>
+          </MudRadioGroup>
+          <MudNumericField @bind-Value="_formModel.MessagesCount"
+                           Disabled="@(_formModel.Type == ReceiveType.All)"
+                           For="@(() => _formModel.MessagesCount)"
+                           T="int?"
+                           Class="px-0 ma-0 pa-0 py-0"
+                           Min="1"
+                           Max="250"
+                           Immediate="true"
+                           HelperText="Messages count">
+          </MudNumericField>
+          <MudNumericField @bind-Value="_formModel.FromSequenceNumber"
+                           T="long?"
+                           For="@(() => _formModel.FromSequenceNumber)"
+                           Disabled="@(_formModel.Type == ReceiveType.All || _formModel.Mode == ReceiveMode.ReceiveAndDelete)"
+                           Class="px-0 ma-0 pa-0 py-0"
+                           Min="0"
+                           Immediate="true"
+                           HelperText="From sequence number">
+          </MudNumericField>
+        </MudField>
+      </MudForm>
+    </MudPaper>
+  </DialogContent>
+  <DialogActions>
+    <MudButton ButtonType="ButtonType.Reset"
+               Color="Color.Default"
+               OnClick="@(() => { Model.DialogVisible = false; })"
+               Class="px-10">
+      Close
+    </MudButton>
+    <MudButton ButtonType="ButtonType.Button"
+               Color="Color.Success"
+               OnClick="@(() => Model.OnSubmitReceiveForm(form, _formModel, default))"
+               Class="px-10">
+      Receive
+    </MudButton>
+  </DialogActions>
 </MudDialog>
 
 @code {
-    [Parameter]
-    public string ConnectionName { get; set; }
-    [Parameter]
-    public string QueueOrTopicName { get; set; }
-    [Parameter]
-    public string? SubscriptionName { get; set; }
-    [Inject]
-    IMessagesViewModel Model { get; set; }
-    MudForm form;
-    ReceiveMessagesForm _formModel;
-    ReceiveMessageFormValidator _validator = new ReceiveMessageFormValidator();
+  [Parameter]
+  public string ConnectionName { get; set; }
+  [Parameter]
+  public string QueueOrTopicName { get; set; }
+  [Parameter]
+  public string? SubscriptionName { get; set; }
+  [Inject]
+  IMessagesViewModel Model { get; set; }
+  MudForm form;
+  ReceiveMessagesForm _formModel;
+  ReceiveMessageFormValidator _validator = new ReceiveMessageFormValidator();
 
-    protected override async Task OnInitializedAsync()
+  protected override async Task OnInitializedAsync()
+  {
+    _formModel = new ReceiveMessagesForm
     {
-        _formModel = new ReceiveMessagesForm
-        {
-            MessagesCount = 10,
-            Type = ReceiveType.ByCount
-        };
+      MessagesCount = 10,
+      Type = ReceiveType.ByCount
+    };
 
-        Model.Initialize(
-            new CurrentMessagesEntity(ConnectionName, QueueOrTopicName, SubscriptionName));
+    Model.Initialize(
+      new CurrentMessagesEntity(ConnectionName, QueueOrTopicName, SubscriptionName));
 
-        Model.PropertyChanged += (_, _) => StateHasChanged();
-    }
+    Model.PropertyChanged += (_, _) => StateHasChanged();
+  }
 }

--- a/src/Ui/Website/ViewModels/IMessagesViewModel.cs
+++ b/src/Ui/Website/ViewModels/IMessagesViewModel.cs
@@ -11,6 +11,7 @@ public interface IMessagesViewModel : INotifyPropertyChanged
 {
     ObservableCollection<Message> Messages { get; }
     bool DialogVisible { get; set; }
+    bool IsPeekMode(ReceiveMessagesForm formModel);
     bool CanPeekMore(ReceiveMessagesForm formModel);
     Task PeekMore(ReceiveMessagesForm formModel, CancellationToken cancellationToken);
     Task OnSubmitReceiveForm(
@@ -20,4 +21,5 @@ public interface IMessagesViewModel : INotifyPropertyChanged
     void Initialize(CurrentMessagesEntity entity);
     Task ViewMessageDetails(Message? message, bool editMode);
     Task Requeue(string queueOrTopicName, MessageDetailsModel message);
+    Task Delete(Message message, SubQueue subQueue);
 }

--- a/src/Ui/Website/ViewModels/MessagesViewModel.cs
+++ b/src/Ui/Website/ViewModels/MessagesViewModel.cs
@@ -56,10 +56,14 @@ public class MessagesViewModel : IMessagesViewModel
         }
     }
 
+    public bool IsPeekMode(ReceiveMessagesForm formModel)
+    {
+        return formModel.Mode == ReceiveMode.PeekLock;
+    }
+
     public bool CanPeekMore(ReceiveMessagesForm formModel) =>
         Messages.Any() &&
-        formModel.Mode == ReceiveMode.PeekLock &&
-        formModel.Type == ReceiveType.ByCount;
+        formModel is { Mode: ReceiveMode.PeekLock, Type: ReceiveType.ByCount };
 
     public async Task PeekMore(
         ReceiveMessagesForm formModel,
@@ -120,7 +124,7 @@ public class MessagesViewModel : IMessagesViewModel
             }
         };
 
-        var dialogReference = _dialogService.Show<MessageDetailsDialog>(
+        IDialogReference? dialogReference = await _dialogService.ShowAsync<MessageDetailsDialog>(
             "Message details",
             parameters,
             new DialogOptions
@@ -133,11 +137,11 @@ public class MessagesViewModel : IMessagesViewModel
                 Position = DialogPosition.Center
             });
 
-        var dialogResult = await dialogReference.Result;
+        DialogResult? dialogResult = await dialogReference.Result;
 
-        if (!dialogResult.Cancelled && dialogResult.Data is RequeueMessage requeueMessage)
+        if (dialogResult is { Canceled: false, Data: RequeueMessage requeueMessage })
         {
-            Requeue(requeueMessage.QueueOrTopicName, requeueMessage.Message);
+            await Requeue(requeueMessage.QueueOrTopicName, requeueMessage.Message);
         }
     }
 
@@ -145,10 +149,13 @@ public class MessagesViewModel : IMessagesViewModel
     {
         try
         {
-            var sendMessageResult = await _messageService.SendMessagesAsync(
+            Result sendMessageResult = await _messageService.SendMessagesAsync(
                 _entity.ConnectionName,
                 queueOrTopicName,
-                new[] { message.ToSendMessage() },
+                new[]
+                {
+                    message.ToSendMessage()
+                },
                 default);
 
             //TODO: rethink the SendMessageAsync method result
@@ -166,6 +173,55 @@ public class MessagesViewModel : IMessagesViewModel
         catch (Exception ex)
         {
             _snackbar.Add($"Error while sending message. Error: {ex.Message}", Severity.Error);
+        }
+    }
+
+    public async Task Delete(Message message, SubQueue subQueue)
+    {
+        try
+        {
+            var parameters = new DialogParameters();
+            parameters.Add(
+                "ContentText",
+                $"Are you sure you want to remove message with sequence " +
+                $"number {message.SystemProperties.SequenceNumber}?");
+
+            IDialogReference? dialog = await _dialogService.ShowAsync<ConfirmDialog>(
+                "Confirm",
+                parameters,
+                new DialogOptions
+                {
+                    CloseOnEscapeKey = true
+                });
+
+            DialogResult? result = await dialog.Result;
+
+            if (result.Data is false)
+            {
+                return;
+            }
+
+            Result sendMessageResult = await _messageService.DeleteMessage(
+                _entity.ConnectionName,
+                _entity.QueueOrTopicName,
+                _entity.SubscriptionName,
+                subQueue,
+                message.SystemProperties.SequenceNumber,
+                CancellationToken.None);
+
+            if (sendMessageResult.Count == 1)
+            {
+                _snackbar.Add("Message successfully removed", Severity.Success);
+                Messages.Remove(message);
+            }
+            else
+            {
+                _snackbar.Add("Message was not removed. Please try again.", Severity.Warning);
+            }
+        }
+        catch (Exception ex)
+        {
+            _snackbar.Add($"Error while removing message. Error: {ex.Message}", Severity.Error);
         }
     }
 


### PR DESCRIPTION
Fixed #28. Added options to remove peeked messages from queues/topics. The limitation is the deeper the sequence number, the longer the process will take - messages need to be received in PeekLock mode and completed:

![image](https://github.com/Carael/CrossBusExplorer/assets/6861396/8af8470c-9a13-4ca7-8702-18c954b7b2ef)
