### PR TITLE
Transport Type Support

### DIFF
--- a/src/Api/Host/ConnectionManagement.cs
+++ b/src/Api/Host/ConnectionManagement.cs
@@ -12,7 +12,7 @@ public class ConnectionManagement : IConnectionManagement
         throw new NotImplementedException();
     }
     public Task<ServiceBusConnection> SaveAsync(string name, string connectionString, string folder,
-        CancellationToken cancellationToken)
+        ServiceBusTransportType transportType, CancellationToken cancellationToken)
     {
         throw new NotImplementedException();
     }

--- a/src/Core/Management.Contracts/IConnectionManagement.cs
+++ b/src/Core/Management.Contracts/IConnectionManagement.cs
@@ -8,6 +8,7 @@ public interface IConnectionManagement
         string name, 
         string connectionString,
         string folder,
+        ServiceBusTransportType transportType,
         CancellationToken cancellationToken);
     Task DeleteAsync(string name, CancellationToken cancellationToken);
 }

--- a/src/Core/Management.Contracts/ServiceBusConnection.cs
+++ b/src/Core/Management.Contracts/ServiceBusConnection.cs
@@ -10,7 +10,8 @@ public class ServiceBusConnection
         string? entityPath,
         string sharedAccessKey,
         string sharedAccessSignature,
-        string sharedAccessKeyName)
+        string sharedAccessKeyName,
+        ServiceBusTransportType transportType = ServiceBusTransportType.AmqpTcp)
     {
         Name = name;
         ConnectionString = connectionString;
@@ -20,6 +21,7 @@ public class ServiceBusConnection
         SharedAccessKey = sharedAccessKey;
         SharedAccessSignature = sharedAccessSignature;
         SharedAccessKeyName = sharedAccessKeyName;
+        TransportType = transportType;
     }
     public string Name { get; }
     public string ConnectionString { get; }
@@ -29,4 +31,5 @@ public class ServiceBusConnection
     public string SharedAccessKey { get; }
     public string SharedAccessSignature { get; }
     public string SharedAccessKeyName { get; }
+    public ServiceBusTransportType TransportType { get; }
 }

--- a/src/Core/Management.Contracts/ServiceBusTransportType.cs
+++ b/src/Core/Management.Contracts/ServiceBusTransportType.cs
@@ -1,0 +1,14 @@
+namespace CrossBusExplorer.Management.Contracts;
+
+public enum ServiceBusTransportType
+{
+    /// <summary>
+    /// AMQP over TCP transport
+    /// </summary>
+    AmqpTcp = 0,
+    
+    /// <summary>
+    /// AMQP over WebSockets transport (recommended for restrictive network environments)
+    /// </summary>
+    AmqpWebSockets = 1
+}

--- a/src/Core/Management/ConnectionManagement.cs
+++ b/src/Core/Management/ConnectionManagement.cs
@@ -36,13 +36,14 @@ public class ConnectionManagement : IConnectionManagement
         string name,
         string connectionString,
         string folder,
+        ServiceBusTransportType transportType,
         CancellationToken cancellationToken)
     {
         IDictionary<string, ServiceBusConnection> connections =
             await _managementStorage.ReadAsync(cancellationToken);
 
         var connection = ServiceBusConnectionStringHelper.GetServiceBusConnection(
-            name, connectionString);
+            name, connectionString, transportType);
         
         //TODO: add to folder
 

--- a/src/Core/Management/ServiceBusConnectionStringHelper.cs
+++ b/src/Core/Management/ServiceBusConnectionStringHelper.cs
@@ -1,5 +1,6 @@
 using Azure.Messaging.ServiceBus;
 using CrossBusExplorer.Management.Contracts;
+using ServiceBusTransportType = CrossBusExplorer.Management.Contracts.ServiceBusTransportType;
 namespace CrossBusExplorer.Management;
 
 public static class ServiceBusConnectionStringHelper
@@ -39,7 +40,8 @@ public static class ServiceBusConnectionStringHelper
     }
     public static ServiceBusConnection GetServiceBusConnection(
         string name,
-        string connectionString)
+        string connectionString,
+        ServiceBusTransportType transportType = ServiceBusTransportType.AmqpTcp)
     {
         var properties =
             ServiceBusConnectionStringProperties.Parse(connectionString);
@@ -52,6 +54,7 @@ public static class ServiceBusConnectionStringHelper
             properties.EntityPath,
             properties.SharedAccessKey,
             properties.SharedAccessSignature,
-            properties.SharedAccessKeyName);
+            properties.SharedAccessKeyName,
+            transportType);
     }
 }

--- a/src/Core/ServiceBus/MessageService.cs
+++ b/src/Core/ServiceBus/MessageService.cs
@@ -17,6 +17,25 @@ public class MessageService : IMessageService
         _connectionManagement = connectionManagement;
     }
 
+    private ServiceBusClientOptions GetServiceBusClientOptions(
+        CrossBusExplorer.Management.Contracts.ServiceBusTransportType transportType)
+    {
+        return new ServiceBusClientOptions
+        {
+            TransportType = transportType == CrossBusExplorer.Management.Contracts.ServiceBusTransportType.AmqpTcp
+                ? Azure.Messaging.ServiceBus.ServiceBusTransportType.AmqpTcp
+                : Azure.Messaging.ServiceBus.ServiceBusTransportType.AmqpWebSockets,
+            RetryOptions = new ServiceBusRetryOptions
+            {
+                Mode = ServiceBusRetryMode.Exponential,
+                MaxRetries = 3,
+                Delay = TimeSpan.FromSeconds(1),
+                MaxDelay = TimeSpan.FromSeconds(10),
+                TryTimeout = TimeSpan.FromSeconds(60)
+            }
+        };
+    }
+
     public async Task<IReadOnlyList<Message>> GetMessagesAsync(
         string connectionName,
         string queueOrTopicName,
@@ -33,7 +52,9 @@ public class MessageService : IMessageService
             var connection =
                 await _connectionManagement.GetAsync(connectionName, cancellationToken);
 
-            await using ServiceBusClient client = new ServiceBusClient(connection.ConnectionString);
+            await using ServiceBusClient client = new ServiceBusClient(
+                connection.ConnectionString,
+                GetServiceBusClientOptions(connection.TransportType));
 
             await using var receiver =
                 GetReceiver(client, queueOrTopicName, subscriptionName, subQueue, mode);
@@ -71,7 +92,9 @@ public class MessageService : IMessageService
         var connection =
             await _connectionManagement.GetAsync(connectionName, cancellationToken);
 
-        await using var client = new ServiceBusClient(connection.ConnectionString);
+        await using var client = new ServiceBusClient(
+            connection.ConnectionString,
+            GetServiceBusClientOptions(connection.TransportType));
         await using ServiceBusSender sender = client.CreateSender(queueOrTopicName);
 
         return await SendMessagesInternalAsync(
@@ -91,7 +114,9 @@ public class MessageService : IMessageService
         var connection =
             await _connectionManagement.GetAsync(connectionName, cancellationToken);
 
-        await using ServiceBusClient client = new ServiceBusClient(connection.ConnectionString);
+        await using ServiceBusClient client = new ServiceBusClient(
+            connection.ConnectionString,
+            GetServiceBusClientOptions(connection.TransportType));
         await using var receiver = GetReceiver(
             client,
             topicOrQueueName,
@@ -127,7 +152,9 @@ public class MessageService : IMessageService
         var connection =
             await _connectionManagement.GetAsync(connectionName, cancellationToken);
 
-        await using ServiceBusClient client = new ServiceBusClient(connection.ConnectionString);
+        await using ServiceBusClient client = new ServiceBusClient(
+            connection.ConnectionString,
+            GetServiceBusClientOptions(connection.TransportType));
         await using ServiceBusReceiver receiver = GetReceiver(
             client,
             topicOrQueueName,
@@ -172,7 +199,9 @@ public class MessageService : IMessageService
         var connection =
             await _connectionManagement.GetAsync(connectionName, cancellationToken);
 
-        await using var client = new ServiceBusClient(connection.ConnectionString);
+        await using var client = new ServiceBusClient(
+            connection.ConnectionString,
+            GetServiceBusClientOptions(connection.TransportType));
 
         await using ServiceBusReceiver receiver =
             GetReceiver(client, queueOrTopicName, subscriptionName, subQueue, ReceiveMode.PeekLock);

--- a/src/Ui/Website/Models/SaveConnectionForm.cs
+++ b/src/Ui/Website/Models/SaveConnectionForm.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using CrossBusExplorer.Management;
+using CrossBusExplorer.Management.Contracts;
 using CrossBusExplorer.Website.Extensions;
 using MudBlazor;
 namespace CrossBusExplorer.Website.Models;
@@ -51,6 +52,18 @@ public class SaveConnectionForm : INotifyPropertyChanged
         set
         {
             _folder = value;
+            this.Notify(PropertyChanged);
+        }
+    }
+
+    private ServiceBusTransportType _transportType = ServiceBusTransportType.AmqpTcp;
+    [Label("Transport Type")]
+    public ServiceBusTransportType TransportType
+    {
+        get => _transportType;
+        set
+        {
+            _transportType = value;
             this.Notify(PropertyChanged);
         }
     }

--- a/src/Ui/Website/Models/ServiceBusConnectionFolder.cs
+++ b/src/Ui/Website/Models/ServiceBusConnectionFolder.cs
@@ -11,7 +11,7 @@ public class ServiceBusConnectionWithFolder : ServiceBusConnection
         Folder = folder;
     }
     
-    public ServiceBusConnectionWithFolder(ServiceBusConnection serviceBusConnection, string folder) : base(serviceBusConnection.Name, serviceBusConnection.ConnectionString, serviceBusConnection.Endpoint, serviceBusConnection.FullyQualifiedName, serviceBusConnection.EntityPath, serviceBusConnection.SharedAccessKey, serviceBusConnection.SharedAccessSignature, serviceBusConnection.SharedAccessKeyName)
+    public ServiceBusConnectionWithFolder(ServiceBusConnection serviceBusConnection, string folder) : base(serviceBusConnection.Name, serviceBusConnection.ConnectionString, serviceBusConnection.Endpoint, serviceBusConnection.FullyQualifiedName, serviceBusConnection.EntityPath, serviceBusConnection.SharedAccessKey, serviceBusConnection.SharedAccessSignature, serviceBusConnection.SharedAccessKeyName, serviceBusConnection.TransportType)
     {
         Folder = folder;
     }

--- a/src/Ui/Website/Pages/Connections.razor
+++ b/src/Ui/Website/Pages/Connections.razor
@@ -1,6 +1,7 @@
 ﻿@page "/"
 @page "/connections"
 @using CrossBusExplorer.Website.Models
+@using CrossBusExplorer.Management.Contracts
 
 <PageTitle>Connections</PageTitle>
 
@@ -130,6 +131,13 @@
                                   Immediate="true"/>
                     <MudTextField @bind-Value="@Model.SaveConnectionForm.Name"
                                   For="@(() => Model.SaveConnectionForm.Name)"/>
+                    <MudSelect T="ServiceBusTransportType"
+                               Label="Transport Type"
+                               @bind-Value="@Model.SaveConnectionForm.TransportType"
+                               For="@(() => Model.SaveConnectionForm.TransportType)">
+                        <MudSelectItem Value="@ServiceBusTransportType.AmqpTcp">AMQP over TCP</MudSelectItem>
+                        <MudSelectItem Value="@ServiceBusTransportType.AmqpWebSockets">AMQP over WebSockets</MudSelectItem>
+                    </MudSelect>
                     <MudAutocomplete
                         T="string"
                         For="@(() => Model.SaveConnectionForm.Folder)"

--- a/src/Ui/Website/ViewModels/ConnectionsViewModel.cs
+++ b/src/Ui/Website/ViewModels/ConnectionsViewModel.cs
@@ -210,6 +210,7 @@ public class ConnectionsViewModel : IConnectionsViewModel
         string name,
         string connectionString,
         string folder,
+        ServiceBusTransportType transportType,
         CancellationToken cancellationToken)
     {
         ServiceBusConnection newConnection =
@@ -217,6 +218,7 @@ public class ConnectionsViewModel : IConnectionsViewModel
                 name,
                 connectionString,
                 folder,
+                transportType,
                 cancellationToken);
 
         RemoveOrReplace(new ServiceBusConnectionWithFolder(newConnection, folder));
@@ -256,7 +258,8 @@ public class ConnectionsViewModel : IConnectionsViewModel
             {
                 Name = model.Name,
                 ConnectionString = model.ConnectionString,
-                Folder = TryGetFolderSettings(Folders, model?.Name)?.Name
+                Folder = TryGetFolderSettings(Folders, model?.Name)?.Name,
+                TransportType = model.TransportType
             };
         _saveDialogVisible = true;
         _saveConnectionForm.PropertyChanged += (_, _) =>
@@ -294,6 +297,7 @@ public class ConnectionsViewModel : IConnectionsViewModel
                 _saveConnectionForm.ConnectionString!),
             _saveConnectionForm.ConnectionString!,
             _saveConnectionForm.Folder ?? "",
+            _saveConnectionForm.TransportType,
             default);
 
         _saveDialogVisible = false;


### PR DESCRIPTION
This pull request adds support for specifying the Service Bus transport type (AMQP over TCP or AMQP over WebSockets) when saving and using connections throughout the application. This allows to consume messages in some corporate environments with specific firewall rules like mentioned in this Issue #67 

<img width="705" height="481" alt="Screenshot 2025-11-12 120341" src="https://github.com/user-attachments/assets/55e4f051-aa1a-437b-b842-1301c6dfd23d" />
<img width="669" height="450" alt="Screenshot 2025-11-12 120400" src="https://github.com/user-attachments/assets/03f88dd4-d875-4b8e-9ba0-94ef789190c6" />
